### PR TITLE
Fix EnumVarnamesConverter resolvedSchema nullpointer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>0.1.0-beta</version>
+    <version>1.0.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/EnumVarnamesConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/EnumVarnamesConverter.java
@@ -29,7 +29,7 @@ public class EnumVarnamesConverter implements ModelConverter {
             // First, resolve the schema for current type
             final var resolvedSchema = chain.next().resolve(type, context, chain);
             // If resolved schema type has enum values, resolve and add x-enum-varnames
-            if(resolvedSchema.getEnum() != null && !resolvedSchema.getEnum().isEmpty()) {
+            if(resolvedSchema != null && resolvedSchema.getEnum() != null && !resolvedSchema.getEnum().isEmpty()) {
                 // Find enum name values, and add them to "x-enum-varnames" extension.
                 // This makes the generated enum consts have the same property names as the java enums has declared.
                 final var enumValues = resolvedSchema.getEnum();


### PR DESCRIPTION
 resolvedSchema can be null if a type has a property annotated with @JsonUnwrapped. Will then not try to resolve enum varnames from this.