### PR TITLE
Support providing OpenAPI to OpenApiResource after construction.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiResource.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiResource.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 @Path("/openapi.{type:json|yaml}")
 public class OpenApiResource {
-    private final OpenAPI resolvedOpenAPI;
+    private OpenAPI resolvedOpenAPI;
     private final ObjectMapper jsonOutputMapper;
     private final ObjectMapper yamlOutputMapper;
 
@@ -36,7 +36,7 @@ public class OpenApiResource {
             final OpenAPI resolvedOpenAPI,
             final ObjectMapper jsonOutputMapper,
             final ObjectMapper yamlOutputMapper) {
-        this.resolvedOpenAPI = Objects.requireNonNull(resolvedOpenAPI);
+        this.resolvedOpenAPI = resolvedOpenAPI;
         this.jsonOutputMapper = withDeterministicOutput(Objects.requireNonNull(jsonOutputMapper));
         this.yamlOutputMapper = withDeterministicOutput(Objects.requireNonNull(yamlOutputMapper));
     }
@@ -50,6 +50,10 @@ public class OpenApiResource {
 
     public OpenApiResource(final OpenAPI resolvedOpenAPI) {
         this(resolvedOpenAPI, ObjectMapperFactory.createJson(), ObjectMapperFactory.createYaml());
+    }
+
+    public void setResolvedOpenAPI(final OpenAPI resolvedOpenAPI) {
+        this.resolvedOpenAPI = Objects.requireNonNull(resolvedOpenAPI);
     }
 
     public boolean wantsYaml(final String type) {


### PR DESCRIPTION
So that it can be initialized before resolvedOpenAPI has been created.

One must then set resolvedOpenAPI later, before first use of endpoint.