### PR TITLE
object value deserializer modifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -72,6 +72,12 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>5.11.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
             <version>5.11.4</version>
             <scope>test</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/BeanDescriptionMatcher.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/BeanDescriptionMatcher.java
@@ -1,0 +1,10 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.databind.BeanDescription;
+
+/**
+ * Used to determine if a JsonParserPreProcessor should be applied to given beanDesc
+ */
+public interface BeanDescriptionMatcher {
+    public boolean isMatch(final BeanDescription beanDesc);
+}

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializer.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializer.java
@@ -1,0 +1,43 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * Wraps given wrappedDeserializer and applies given JsonParserPreProcessor before the wrapped deserializer is called
+ * to deserialize.
+ * <p>
+ * This is used to support deserialization of types that was serialized to a different format than what the current
+ * default deserialization supports.
+ * <p>
+ * preProcessor can change the incoming json to a form/value that the current deserializer can handle.
+ */
+public class JsonParserPreProcessingDeserializer<T> extends JsonDeserializer<T> {
+    private final JsonDeserializer<T> wrappedDeserializer;
+    private final JsonParserPreProcessor preProcessor;
+
+    public JsonParserPreProcessingDeserializer(
+            final JsonDeserializer<T> wrappedDeserializer,
+            final JsonParserPreProcessor preProcessor) {
+        this.wrappedDeserializer = Objects.requireNonNull(wrappedDeserializer);
+        this.preProcessor = Objects.requireNonNull(preProcessor);
+    }
+
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+        // Pre-process the JSON input
+        final JsonParser preProcessedParser = this.preProcessJsonParser(p);
+
+        // Delegate to the default deserializer
+        return wrappedDeserializer.deserialize(preProcessedParser, ctxt);
+    }
+
+    private JsonParser preProcessJsonParser(final JsonParser originalParser) throws IOException {
+        return this.preProcessor.preProcess(originalParser);
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerModifier.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerModifier.java
@@ -1,0 +1,100 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.BeanDescription;
+import com.fasterxml.jackson.databind.DeserializationConfig;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * This is used to intercept deserialization of certain types (matched by added processorMatcher), and preprocess the
+ * incoming json via added JsonParserPreProcessor before the default deserializer is called with it.
+ * <p>
+ * Can be used to support deserializing various formats for a (super)type without having to add support for it to the
+ * actual type class.
+ */
+public class JsonParserPreProcessingDeserializerModifier extends BeanDeserializerModifier {
+    private final List<PreProcessorMatcher> processorMatchers;
+
+    public JsonParserPreProcessingDeserializerModifier(final List<PreProcessorMatcher> processorMatchers) {
+        this.processorMatchers = Objects.requireNonNull(processorMatchers);
+        processorMatchers.forEach(Objects::requireNonNull);
+    }
+
+    public JsonParserPreProcessingDeserializerModifier() {
+        this(List.of());
+    }
+
+    public JsonParserPreProcessingDeserializerModifier(final PreProcessorMatcher processorMatcher) {
+        this(List.of(processorMatcher));
+    }
+
+    public void addProcessorMatcher(final PreProcessorMatcher processorMatcher) {
+        this.processorMatchers.add(Objects.requireNonNull(processorMatcher));
+    }
+
+    public void addProcessorMatcher(final BeanDescriptionMatcher matcher, final JsonParserPreProcessor processor) {
+        Objects.requireNonNull(matcher);
+        Objects.requireNonNull(processor);
+        final var m = new PreProcessorMatcher() {
+            @Override
+            public boolean isMatch(BeanDescription beanDesc) {
+                return matcher.isMatch(beanDesc);
+            }
+
+            @Override
+            public JsonParser preProcess(JsonParser p) throws IOException {
+                return processor.preProcess(p);
+            }
+
+        };
+        this.addProcessorMatcher(m);
+    }
+
+    /**
+     * If a PreProcessorMatcher matches beanDesc, return the attached JsonParserPreProcessor.
+     * Only the first match found is returned and used. It is the callers responsibility to not add multiple matching
+     * preprocessors, or add them in order so that the correct one is returned here for a given BeanDescription.
+     *
+     * @return Found JsonParserPreProcessor to modify deserializer with, or None if no match is found.
+     */
+    private Optional<PreProcessorMatcher> resolvePreProcessor(final BeanDescription beanDesc) {
+        for(final var matcher: this.processorMatchers) {
+            if(matcher.isMatch(beanDesc)) {
+                return Optional.of(matcher);
+            }
+        }
+        return Optional.empty();
+    }
+
+    private JsonDeserializer<?> wrapIfMatched(final JsonDeserializer<?> defaultSerializer, final BeanDescription beanDesc) {
+        final var maybePreProcessor = this.resolvePreProcessor(beanDesc);
+        if(maybePreProcessor.isPresent()) {
+            return new JsonParserPreProcessingDeserializer<>(
+                    defaultSerializer,
+                    maybePreProcessor.get()
+            );
+        }
+        return defaultSerializer;
+    }
+
+    @Override
+    public JsonDeserializer<?> modifyDeserializer(final DeserializationConfig config,
+                                                  final BeanDescription beanDesc,
+                                                  final JsonDeserializer<?> deserializer) {
+        final var defaultSerializer = super.modifyDeserializer(config, beanDesc, deserializer);
+        return this.wrapIfMatched(defaultSerializer, beanDesc);
+    }
+
+    @Override
+    public JsonDeserializer<?> modifyEnumDeserializer(DeserializationConfig config, JavaType type, BeanDescription beanDesc, JsonDeserializer<?> deserializer) {
+        final var defaultSerializer = super.modifyEnumDeserializer(config, type, beanDesc, deserializer);
+        return this.wrapIfMatched(defaultSerializer, beanDesc);
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessor.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessor.java
@@ -1,0 +1,9 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+
+import java.io.IOException;
+
+public interface JsonParserPreProcessor {
+    public JsonParser preProcess(JsonParser p) throws IOException;
+}

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/ObjectToPropertyPreProcessor.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/ObjectToPropertyPreProcessor.java
@@ -1,0 +1,73 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.BeanDescription;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * ObjectToPropertyPreProcessor is used to modify a deserializer so that an incoming json object is changed to be deserialized
+ * as one of its properties instead of the whole object.
+ * <p>
+ * If for example the deserializer gets an object like this:
+ * <pre>
+ *     {"kode": "VALUE", "kodeverk": "VALUE_TYPE"}
+ * </pre>
+ * This preprocessor can change that so that the input to the deserializer using the parser becomes:
+ * <pre>
+ *     "VALUE"
+ * </pre>
+ * By initializing it with propertyName = "kode".
+ * <p>
+ * If the input JsonParser is not at the start of an object, the given propertyName is not found in the object, or has
+ * no value, the input is passed back either as the original input JsonParser or a new JsonParser containing the current
+ * object. This should then be a no-op. That might lead to a failure to deserialize later.
+ * <p>
+ * Since the propertyName is hardcoded as a string when initializing this class, implementors should add a unit test that
+ * fails if at some later point the propertyName of matchCalss is changed, so that one can detect and fix the hardcoded
+ * propertyName in, before deserialization starts failing. Note also that in this case one must consider compatibility
+ * with old objects serialized with the old propertyName.
+ */
+public class ObjectToPropertyPreProcessor implements PreProcessorMatcher {
+    private final Class<?> matchClass;
+    /**
+     * key of object property to extract and use for deserialization
+     */
+    private final String propertyName;
+
+    public ObjectToPropertyPreProcessor(final Class<?> matchClass, final String propertyName) {
+        this.matchClass = Objects.requireNonNull(matchClass);
+        this.propertyName = Objects.requireNonNull(propertyName);
+    }
+
+    @Override
+    public boolean isMatch(BeanDescription beanDesc) {
+        return beanDesc.getType().isTypeOrSubTypeOf(this.matchClass);
+    }
+
+    @Override
+    public JsonParser preProcess(JsonParser p) throws IOException {
+        // If parser is at start of an object.
+        if(p.currentToken() == JsonToken.START_OBJECT) {
+            final var obj = p.readValueAsTree();
+            if(obj.isObject()) {
+                final var kode = obj.get(this.propertyName);
+                if(kode != null) {
+                    final JsonParser subParser = kode.traverse(p.getCodec());
+                    subParser.nextToken(); // Bring the new parser forward to start of kode value
+                    return subParser;
+                }
+            }
+            // Not an object, or property not found. Continue as if no pre-processing has happened.
+            // Don't think this will ever occur unless some implementation mistake has been done.
+            // If this happens, later deserialization will probably fail.
+            final var passthroughSubParser = obj.traverse(p.getCodec());
+            passthroughSubParser.nextToken(); // Bring the new parser forward to start of kode value
+            return passthroughSubParser;
+        }
+        // Not an object. Continue as if no pre-processing happened.
+        return p;
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/PreProcessorMatcher.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/PreProcessorMatcher.java
@@ -1,0 +1,4 @@
+package no.nav.openapi.spec.utils.jackson;
+
+public interface PreProcessorMatcher extends BeanDescriptionMatcher, JsonParserPreProcessor {
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiResource.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiResource.java
@@ -28,7 +28,7 @@ import java.util.Objects;
  */
 @Path("/openapi.{type:json|yaml}")
 public class OpenApiResource {
-    private final OpenAPI resolvedOpenAPI;
+    private OpenAPI resolvedOpenAPI;
     private final ObjectMapper jsonOutputMapper;
     private final ObjectMapper yamlOutputMapper;
 
@@ -36,7 +36,7 @@ public class OpenApiResource {
             final OpenAPI resolvedOpenAPI,
             final ObjectMapper jsonOutputMapper,
             final ObjectMapper yamlOutputMapper) {
-        this.resolvedOpenAPI = Objects.requireNonNull(resolvedOpenAPI);
+        this.resolvedOpenAPI = resolvedOpenAPI;
         this.jsonOutputMapper = withDeterministicOutput(Objects.requireNonNull(jsonOutputMapper));
         this.yamlOutputMapper = withDeterministicOutput(Objects.requireNonNull(yamlOutputMapper));
     }
@@ -50,6 +50,10 @@ public class OpenApiResource {
 
     public OpenApiResource(final OpenAPI resolvedOpenAPI) {
         this(resolvedOpenAPI, ObjectMapperFactory.createJson(), ObjectMapperFactory.createYaml());
+    }
+
+    public void setResolvedOpenAPI(final OpenAPI resolvedOpenAPI) {
+        this.resolvedOpenAPI = Objects.requireNonNull(resolvedOpenAPI);
     }
 
     public boolean wantsYaml(final String type) {

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerTest.java
@@ -1,0 +1,104 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.BeanDeserializerModifier;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.swagger.v3.core.util.ObjectMapperFactory;
+import no.nav.openapi.spec.utils.jackson.dto.*;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class JsonParserPreProcessingDeserializerTest {
+
+    private static BeanDeserializerModifier makePreProcessingModifier() {
+        final var preProcessorAndMatcher = new ObjectToPropertyPreProcessor(SomeInterface.class, "codeValue");
+        return new JsonParserPreProcessingDeserializerModifier(preProcessorAndMatcher);
+    }
+
+    public static List<ObjectMapper> objectMappers() {
+        final ObjectMapper om = ObjectMapperFactory.createJson();
+        final var deserializerModifier = makePreProcessingModifier();
+        final SimpleModule codeValueSerializedAsObject = new SimpleModule();
+        codeValueSerializedAsObject.addSerializer(new SomeInterfaceSpecialSerializer(true));
+        codeValueSerializedAsObject.setDeserializerModifier(deserializerModifier);
+        final SimpleModule codeValueSerializedAsString = new SimpleModule();
+        codeValueSerializedAsString.addSerializer(new SomeInterfaceSpecialSerializer(false));
+        codeValueSerializedAsString.setDeserializerModifier(deserializerModifier);
+        return List.of(
+                om,
+                om.copy().registerModule(codeValueSerializedAsObject),
+                om.copy().registerModule(codeValueSerializedAsString)
+        );
+    }
+
+    private ContainerA containerA() {
+        return new ContainerA(
+                ValueAnnotatedEnum.VALUE_B,
+                UnAnnotatedEnum.VALUE_A,
+                ObjectAnnotatedEnum.VALUE_A,
+                new OtherData("aaa", 111),
+                List.of(ValueAnnotatedEnum.VALUE_A, ValueAnnotatedEnum.VALUE_B),
+                new NotEnumCodeValue("txt for vvvv", "vvvv")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("objectMappers")
+    public void testRoundTripAllObjectMappers(final ObjectMapper om) throws JsonProcessingException {
+        final ContainerA inp = this.containerA();
+        final String jsonStr = om.writeValueAsString(inp);
+        final ContainerA out = om.readValue(jsonStr, ContainerA.class);
+        assertThat(out).isEqualTo(inp);
+    }
+
+    // Test that containerA serialized with objectmapper always doing objects for SomeInterface can be deserializer with
+    // objectmapper serializing as strings (that has deserializer preprocessing for it)
+    @Test
+    public void testMixingMapperDeserialization() throws JsonProcessingException {
+        final var inp = this.containerA();
+        final var objectMappers = objectMappers();
+        final var alwaysToObjectMapper = objectMappers.get(1);
+        final var alwaysToStringMapper = objectMappers.get(2);
+        final String jsonStr = alwaysToObjectMapper.writeValueAsString(inp);
+        final ContainerA out = alwaysToStringMapper.readValue(jsonStr, ContainerA.class);
+        assertThat(out).isEqualTo(inp);
+    }
+
+    // Test the fallback for when given propertyName is not found in ObjectToPropertyPreProcessor.
+    // Will then fall back to using unmodified JsonParser, which might work.
+    @Test
+    public void testFallbackToPassthrough() throws JsonProcessingException {
+        final ObjectMapper om = ObjectMapperFactory.createJson();
+        final SimpleModule mod = new SimpleModule();
+        // Add deserializermodifier with incorrect propertyName. Will always fail
+        mod.setDeserializerModifier(new JsonParserPreProcessingDeserializerModifier(new ObjectToPropertyPreProcessor(SomeInterface.class, "wrongPropName")));
+        om.registerModule(mod);
+        final var inp = ObjectAnnotatedEnum.VALUE_A;
+        final String jsonStr = om.writeValueAsString(inp);
+        final var out = om.readValue(jsonStr, ObjectAnnotatedEnum.class);
+        assertThat(out).isEqualTo(inp);
+    }
+
+    // Test that changing the definition of a type having JsonFormat(shape = OBJECT) to using JsonValue works, i.e.
+    // data serialized as object can be deserialized with type annotated as JsonValue without doing anything other than
+    // using the preprocessor.
+    @Test
+    public void testChangingFromObjectToValue() throws JsonProcessingException {
+        final var inp = ObjectAnnotatedEnum.VALUE_B;
+        final ObjectMapper om = ObjectMapperFactory.createJson();
+        final SimpleModule mod = new SimpleModule();
+        // Add deserializermodifier with incorrect propertyName. Will always fail
+        mod.setDeserializerModifier(new JsonParserPreProcessingDeserializerModifier(new ObjectToPropertyPreProcessor(SomeInterface.class, "codeValue")));
+        om.registerModule(mod);
+        final String jsonStr = om.writeValueAsString(inp);
+        final var out = om.readValue(jsonStr, ValueAnnotatedEnum.class);
+        assertThat(out.codeValue()).isEqualTo(inp.codeValue());
+        assertThat(out).isEqualTo(ValueAnnotatedEnum.VALUE_B);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/SomeInterfaceSpecialSerializer.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/SomeInterfaceSpecialSerializer.java
@@ -1,0 +1,34 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import no.nav.openapi.spec.utils.jackson.dto.SomeInterface;
+
+import java.io.IOException;
+
+public class SomeInterfaceSpecialSerializer extends StdSerializer<SomeInterface> {
+    /**
+     * If true, all implementations of SomeInterface are serialized as json object with one codeValue property,
+     * regardless of its json annotations.
+     * If false, all implementations are serialized as a json string of codeValue property regardless of its annotations.
+     */
+    private boolean asObject;
+
+    public SomeInterfaceSpecialSerializer(final boolean asObject) {
+        super(SomeInterface.class);
+        this.asObject = asObject;
+    }
+
+    @Override
+    public void serialize(SomeInterface some, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+        if(asObject) {
+            jgen.writeStartObject();
+            jgen.writeStringField("codeValue", some.codeValue());
+            jgen.writeEndObject();
+        } else {
+            jgen.writeString(some.codeValue());
+        }
+    }
+
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ContainerA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ContainerA.java
@@ -1,0 +1,13 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import java.util.List;
+
+public record ContainerA(
+        ValueAnnotatedEnum valueAnnotatedEnum,
+        UnAnnotatedEnum unAnnotatedEnum,
+        ObjectAnnotatedEnum objectAnnotatedEnum,
+        OtherData otherData,
+        List<ValueAnnotatedEnum> listOfValueAnnotatedEnums,
+        NotEnumCodeValue notEnumCodeValue
+) {
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/NotEnumCodeValue.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/NotEnumCodeValue.java
@@ -1,0 +1,11 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+public record NotEnumCodeValue(String txt, String codeValue) implements SomeInterface {
+    @JsonCreator
+    public static NotEnumCodeValue fromString(final String codeValue) {
+        // Just make up some txt value
+        return new NotEnumCodeValue("txt for "+codeValue, codeValue);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ObjectAnnotatedEnum.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ObjectAnnotatedEnum.java
@@ -1,0 +1,36 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public enum ObjectAnnotatedEnum implements SomeInterface {
+    VALUE_A("A"),
+    VALUE_B("B");
+
+    private String codeValue;
+
+    private ObjectAnnotatedEnum(final String codeValue) {
+        this.codeValue = codeValue;
+    }
+
+    @JsonCreator
+    public static ObjectAnnotatedEnum fromCodeValue(final String codeValue) {
+        for(final var v: values()) {
+            if(v.codeValue.equalsIgnoreCase(codeValue)) {
+                return v;
+            }
+        }
+        throw new RuntimeException(codeValue + " not a valid ObjectAnnotatedEnum value");
+    }
+
+    @JsonCreator
+    public static ObjectAnnotatedEnum fromObjectProp(@JsonProperty("codeValue") final String codeValue) {
+        return fromCodeValue(codeValue);
+    }
+
+    public String codeValue() {
+        return codeValue;
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
@@ -1,0 +1,7 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+public record OtherData(
+        String txt1,
+        int num1
+) {
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeInterface.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeInterface.java
@@ -1,0 +1,8 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public interface SomeInterface {
+    @JsonProperty
+    public String codeValue();
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/UnAnnotatedEnum.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/UnAnnotatedEnum.java
@@ -1,0 +1,37 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+// This will by default serialize to/from enum name string
+public enum UnAnnotatedEnum implements SomeInterface {
+    VALUE_A("A"),
+    VALUE_B("B");
+
+    private String codeValue;
+
+    private UnAnnotatedEnum(final String codeValue) {
+        this.codeValue = codeValue;
+    }
+
+    public String codeValue() {
+        return codeValue;
+    }
+
+    // Adds JsonCreator to support deserialization from both name and codeValue.
+    @JsonCreator
+    public static UnAnnotatedEnum fromString(final String str) {
+        // Resolve enum from name or codeValue, so that deserialization works in both cases.
+        try {
+            return UnAnnotatedEnum.valueOf(str);
+        } catch (IllegalArgumentException e) {
+            // Expected exception when we need to try deserializing from codeValue instead
+            for(final var v: values()) {
+                if(v.codeValue.equalsIgnoreCase(str)) {
+                    return v;
+                }
+            }
+            // No match from codeValue either
+            throw new IllegalArgumentException("could not resolve UnAnnotatedEnum from string \"" + str + "\" by name or codeValue.", e);
+        }
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ValueAnnotatedEnum.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ValueAnnotatedEnum.java
@@ -1,0 +1,19 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum ValueAnnotatedEnum implements SomeInterface {
+    VALUE_A("A"),
+    VALUE_B("B");
+
+    private String codeValue;
+
+    private ValueAnnotatedEnum(final String codeValue) {
+        this.codeValue = codeValue;
+    }
+
+    @JsonValue
+    public String codeValue() {
+        return codeValue;
+    }
+}


### PR DESCRIPTION
Adds utilities for creating DeserializerModifier that pre-process incoming json before passing it to default deserializer.

So that one can add compatibility for deserializing types from various incoming json without doing it on each type.

Also adds support for providing OpenAPI to OpenApiResource after construction of it.