### PR TITLE
Vary response header

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/http/DynamicObjectMapperResolverVaryFilter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/http/DynamicObjectMapperResolverVaryFilter.java
@@ -5,8 +5,6 @@ import jakarta.ws.rs.container.ContainerResponseContext;
 import jakarta.ws.rs.container.ContainerResponseFilter;
 import no.nav.openapi.spec.utils.jackson.DynamicObjectMapperResolver;
 
-import java.io.IOException;
-
 /**
  * When using DynamicObjectMapperResolver, the response content becomes dependent on the X-Json-Serializer-Option header.
  * It must therefore be set in the response Vary header to ensure that caches do not serve the wrong content to clients if
@@ -21,7 +19,7 @@ public class DynamicObjectMapperResolverVaryFilter implements ContainerResponseF
     public DynamicObjectMapperResolverVaryFilter() {}
 
     @Override
-    public void filter(ContainerRequestContext req, ContainerResponseContext res) throws IOException {
+    public void filter(ContainerRequestContext req, ContainerResponseContext res) {
         res.getHeaders().add("Vary", DynamicObjectMapperResolver.HEADER_KEY);
     }
 }

--- a/src/main/java/no/nav/openapi/spec/utils/http/DynamicObjectMapperResolverVaryFilter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/http/DynamicObjectMapperResolverVaryFilter.java
@@ -1,0 +1,27 @@
+package no.nav.openapi.spec.utils.http;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import no.nav.openapi.spec.utils.jackson.DynamicObjectMapperResolver;
+
+import java.io.IOException;
+
+/**
+ * When using DynamicObjectMapperResolver, the response content becomes dependent on the X-Json-Serializer-Option header.
+ * It must therefore be set in the response Vary header to ensure that caches do not serve the wrong content to clients if
+ * the client changes the X-Json-Serializer-Option header in between requests to the same URL, and the request content is
+ * cached.
+ * <p>
+ *     This filter should therefore be added to the JAX-RS application whenever DynamicObjectMapperResolver, or a subclass
+ *     of it is used.
+ * </p>
+ */
+public class DynamicObjectMapperResolverVaryFilter implements ContainerResponseFilter {
+    public DynamicObjectMapperResolverVaryFilter() {}
+
+    @Override
+    public void filter(ContainerRequestContext req, ContainerResponseContext res) throws IOException {
+        res.getHeaders().add("Vary", DynamicObjectMapperResolver.HEADER_KEY);
+    }
+}


### PR DESCRIPTION
Added filter that adds Vary: X-Json-Serializer-Option header to all responses.

Needed to avoid wrong content being used for cached responses, if the client changes the header value for different requests to the same URL.