### PR TITLE
Fix dynamic jackson json provider priority

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <licenses>
         <license>
             <name>MIT License</name>
@@ -52,6 +52,16 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+            <version>[2.0, 2.99999)</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>[4.0, 4.99999)</version>
+        </dependency>
         <dependency>
             <groupId>jakarta.ws.rs</groupId>
             <artifactId>jakarta.ws.rs-api</artifactId>

--- a/src/main/java/no/nav/openapi/spec/utils/jackson/DynamicJacksonJsonProvider.java
+++ b/src/main/java/no/nav/openapi/spec/utils/jackson/DynamicJacksonJsonProvider.java
@@ -2,18 +2,15 @@ package no.nav.openapi.spec.utils.jackson;
 
 import com.fasterxml.jackson.jakarta.rs.cfg.JakartaRSFeature;
 import com.fasterxml.jackson.jakarta.rs.json.JacksonJsonProvider;
-import jakarta.ws.rs.Consumes;
-import jakarta.ws.rs.Produces;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.ext.Provider;
+import jakarta.enterprise.inject.Specializes;
+import jakarta.annotation.Priority;
 
 /**
  * Overrides default JacksonJsonProvider to disable the caching of resolved ObjectMapper so that we can resolve to
  * different ObjectMappers based on incoming http request header by using DynamicObjectMapperResolver or similar.
  */
-@Provider
-@Consumes({MediaType.APPLICATION_JSON, "text/json", MediaType.WILDCARD})
-@Produces({MediaType.APPLICATION_JSON, "text/json", MediaType.WILDCARD})
+@Specializes
+@Priority(100)
 public class DynamicJacksonJsonProvider extends JacksonJsonProvider {
     public DynamicJacksonJsonProvider() {
         super();

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/JsonParserPreProcessingDeserializerTest.java
@@ -42,7 +42,7 @@ public class JsonParserPreProcessingDeserializerTest {
                 ValueAnnotatedEnum.VALUE_B,
                 UnAnnotatedEnum.VALUE_A,
                 ObjectAnnotatedEnum.VALUE_A,
-                new OtherData("aaa", 111),
+                new OtherData("aaa", 111, null),
                 List.of(ValueAnnotatedEnum.VALUE_A, ValueAnnotatedEnum.VALUE_B),
                 new NotEnumCodeValue("txt for vvvv", "vvvv")
         );

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/OpenapiCompatObjectMapperModifierTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/OpenapiCompatObjectMapperModifierTest.java
@@ -1,0 +1,34 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.swagger.v3.core.util.ObjectMapperFactory;
+import no.nav.openapi.spec.utils.jackson.dto.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OpenapiCompatObjectMapperModifierTest {
+
+    @Test
+    public void testThatNullSerializesToNotIncluded() throws JsonProcessingException {
+        final var modifier = OpenapiCompatObjectMapperModifier.withDefaultModifications();
+        final var objectMapper = modifier.modify(ObjectMapperFactory.createJson());
+        final var inp = new OtherData("txt1", 1, null);
+        final var jsonStr = objectMapper.writeValueAsString(inp);
+        // Sjekk at null property ikkje er med i serialisert json
+        assertThat(jsonStr).doesNotContain("num2");
+        final var container = new ContainerA(
+                ValueAnnotatedEnum.VALUE_B,
+                UnAnnotatedEnum.VALUE_A,
+                ObjectAnnotatedEnum.VALUE_A,
+                inp,
+                List.of(ValueAnnotatedEnum.VALUE_A, ValueAnnotatedEnum.VALUE_B),
+                new NotEnumCodeValue("txt for vvvv", "vvvv")
+        );
+        final var jsonStr2 = objectMapper.writeValueAsString(container);
+        // Sjekk at null property ikkje er med i serialisert json
+        assertThat(jsonStr2).doesNotContain("num2");
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
@@ -2,6 +2,7 @@ package no.nav.openapi.spec.utils.jackson.dto;
 
 public record OtherData(
         String txt1,
-        int num1
+        int num1,
+        Integer num2
 ) {
 }


### PR DESCRIPTION
Use `@Specializes` and `@Priority` annotations so that dependency injection system prioritizes the DynamicJacksonJsonProvider over other (default) providers of the same service, which is present in the container environment.

Without this, sometimes the default provider that does not enable dynamic object mapper lookup (and disables caching) would take precedence, and so the context dependent object mapper resolver would not work as intended.