### PR TITLE
Add TimeTypesModelConverter, to get a correct openapi spec generated …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.3.1</version>
+    <version>1.4.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiSetupHelper.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/OpenApiSetupHelper.java
@@ -80,7 +80,11 @@ public class OpenApiSetupHelper {
     protected OpenAPI createWithCustomizations(final OpenAPIConfiguration baseConfig) throws OpenApiConfigurationException {
         final var context = this.buildContext(baseConfig);
         // EnumVarnamesConverter legger til x-enum-varnames for property namn på genererte enum objekt.
-        context.setModelConverters(Set.of(new EnumVarnamesConverter(this.objectMapper())));
+        // TimeTypesModelConverter konverterer Duration til OpenAPI string med format "duration".
+        context.setModelConverters(Set.of(
+                new EnumVarnamesConverter(this.objectMapper()),
+                new TimeTypesModelConverter(this.objectMapper())
+        ));
         // Konverter og rename enums, legg til nullable på Optional returtyper:
         final var optionalResponseTypeAdjustingReader = new OptionalResponseTypeAdjustingReader(baseConfig);
         optionalResponseTypeAdjustingReader.setApplication(this.application); // <- Nødvendig for at @ApplicationPath skal få effekt

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/TimeTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/TimeTypesModelConverter.java
@@ -1,0 +1,52 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.oas.models.media.Schema;
+import no.nav.openapi.spec.utils.openapi.models.DurationSchema;
+
+import java.time.Duration;
+import java.util.Iterator;
+
+/**
+ * Overstyrer standard openapi spesifikasjonsgenerering for Duration verdier.
+ * <p>
+ * Duration verdier blir i utgangspunktet definert som object i openapi spesifikasjonen, med alle interne properties
+ * spesifisert. Dette stemmer ikkje med faktisk serialisering/deserialisering, som med SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS
+ * disabled i ObjectMapper vil (de)serialisere Duration frå/til ISO-8601 string.
+ * <p>
+ * Denne ModelConverter overstyrer openapi spesifikasjonsgenerering av Duration til å bli string type med format "duration".
+ * Henta frå <a href="https://github.com/swagger-api/swagger-core/issues/2784#issuecomment-388325057">...</a>
+ * <p>
+ * Den er navngitt TimeTypesModelConverter sidan det kanskje vil vere aktuelt å legge til kode for fleire typer som har
+ * med tid å gjere seinare, ved behov.
+ */
+public class TimeTypesModelConverter implements ModelConverter {
+    private final ObjectMapper objectMapper;
+
+    public TimeTypesModelConverter(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        if(type.isSchemaProperty()) {
+            final JavaType javaType = this.objectMapper.constructType(type.getType());
+            if(javaType != null) {
+                final Class<?> cls = javaType.getRawClass();
+                if(Duration.class.isAssignableFrom(cls)) {
+                    return new DurationSchema();
+                }
+            }
+        }
+        if(chain.hasNext()) {
+            return chain.next().resolve(type, context, chain);
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/models/DurationSchema.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/models/DurationSchema.java
@@ -37,13 +37,12 @@ public class DurationSchema extends Schema<Duration> {
     @Override
     protected Duration cast(Object value) {
         if (value != null) {
-            try {
-                if (value instanceof Duration) {
-                    return (Duration) value;
-                } else if (value instanceof String) {
-                    return Duration.parse((String) value);
-                }
-            } catch (Exception e) {
+            if (value instanceof Duration) {
+                return (Duration) value;
+            } else if (value instanceof String) {
+                return Duration.parse((String) value);
+            } else {
+                throw new ClassCastException("Cannot cast " + value.getClass() + " to Duration");
             }
         }
         return null;

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/models/DurationSchema.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/models/DurationSchema.java
@@ -1,0 +1,81 @@
+package no.nav.openapi.spec.utils.openapi.models;
+
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
+import no.nav.openapi.spec.utils.openapi.TimeTypesModelConverter;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * DurationSchema blir brukt av {@link TimeTypesModelConverter}.
+ * <p>
+ * Inspirert av <a href="https://github.com/swagger-api/swagger-core/pull/4821/files">...</a>
+ */
+public class DurationSchema extends Schema<Duration> {
+
+    public DurationSchema() {
+        this(SpecVersion.V30);
+    }
+
+    public DurationSchema(SpecVersion specVersion) {
+        super("string", "duration", specVersion);
+    }
+
+    @Override
+    public DurationSchema format(String format) {
+        super.setFormat(format);
+        return this;
+    }
+
+    @Override
+    public DurationSchema _default(Duration _default) {
+        super.setDefault(_default);
+        return this;
+    }
+
+    @Override
+    protected Duration cast(Object value) {
+        if (value != null) {
+            try {
+                if (value instanceof Duration) {
+                    return (Duration) value;
+                } else if (value instanceof String) {
+                    return Duration.parse((String) value);
+                }
+            } catch (Exception e) {
+            }
+        }
+        return null;
+    }
+
+    public DurationSchema addEnumItem(Duration _enumItem) {
+        super.addEnumItemObject(_enumItem);
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode());
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("class DurationSchema {\n");
+        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
@@ -1,5 +1,7 @@
 package no.nav.openapi.spec.utils.openapi;
 
+import java.time.Duration;
+
 /**
  * Kun for bruk i OpenapiGenerateTest
  */
@@ -7,4 +9,5 @@ public class DummyDto {
     public int nummerProperty = 123;
     public String tekstProperty;
     public DummyEnum enumProperty = DummyEnum.DUMMY_V1;
+    public Duration durationProperty = Duration.parse("P20DT1H13S");
 }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
@@ -35,7 +35,7 @@ public class OpenapiGenerateTest {
         assertThat(schemas).containsKey("DummyDto");
         final var dummyDto = schemas.get("DummyDto");
         Map<String, Schema> properties = dummyDto.getProperties();
-        assertThat(properties).containsKeys("nummerProperty", "tekstProperty", "enumProperty");
+        assertThat(properties).containsKeys("nummerProperty", "tekstProperty", "enumProperty", "durationProperty");
         assertThat(properties.get("nummerProperty").getType()).isEqualTo("integer");
         assertThat(properties.get("tekstProperty").getType()).isEqualTo("string");
         // Sjekk at reskriving til å ha enums som refs fungerte
@@ -54,6 +54,8 @@ public class OpenapiGenerateTest {
         } else {
             fail();
         }
+        assertThat(properties.get("durationProperty").getType()).isEqualTo("string");
+        assertThat(properties.get("durationProperty").getFormat()).isEqualTo("duration");
     }
 
     @Test


### PR DESCRIPTION
…for java.time.Duration properties.

Before this, the openapi spec generated for properties of type java.time.Duration was an object with lots of internal properties, which did not match the (de)serialization actually done by the server.

This change fixes that, so that Duration properties become string properties, with format "duration".

The Duration is (de)serialized from/to string with ISO 8601 format, so this will then be a correct openapi spec.