### PR TITLE
Add YearMonthSchema to TimeTypesModelConverter.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/TimeTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/TimeTypesModelConverter.java
@@ -7,22 +7,30 @@ import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.oas.models.media.Schema;
 import no.nav.openapi.spec.utils.openapi.models.DurationSchema;
+import no.nav.openapi.spec.utils.openapi.models.YearMonthSchema;
 
 import java.time.Duration;
+import java.time.YearMonth;
 import java.util.Iterator;
 
 /**
- * Overstyrer standard openapi spesifikasjonsgenerering for Duration verdier.
+ * Overstyrer standard openapi spesifikasjonsgenerering for java.time.* verdier.
  * <p>
- * Duration verdier blir i utgangspunktet definert som object i openapi spesifikasjonen, med alle interne properties
- * spesifisert. Dette stemmer ikkje med faktisk serialisering/deserialisering, som med SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS
- * disabled i ObjectMapper vil (de)serialisere Duration frå/til ISO-8601 string.
+ * swagger openapi generator har ikkje spesiell støtte for java.time.* typer. Openapi spesifikasjon for disse blir derfor
+ * i utgangspunktet generert som object med alle interne properties spesifisert. Dette stemmer ikkje med faktisk
+ * (de)serialisering i jackson når ObjectMapper er konfigurert til å bruke JavaTimeModule. Då blir disse (de)serialisert
+ * som string.
  * <p>
- * Denne ModelConverter overstyrer openapi spesifikasjonsgenerering av Duration til å bli string type med format "duration".
- * Henta frå <a href="https://github.com/swagger-api/swagger-core/issues/2784#issuecomment-388325057">...</a>
+ * Meir spesifikt blir java.time.Duration verdier, når SerializationFeature.WRITE_DURATIONS_AS_TIMESTAMPS er disabled i
+ * ObjectMapper, (de)serialisert frå/til ISO-8601 string.
  * <p>
- * Den er navngitt TimeTypesModelConverter sidan det kanskje vil vere aktuelt å legge til kode for fleire typer som har
- * med tid å gjere seinare, ved behov.
+ * Denne ModelConverter overstyrer derfor openapi spesifikasjonsgenerering av nokre java.time.* typer med å spesifisere
+ * returnere Schema instanser for disse, som igjen spesifiserer type og format som stemmer med det jackson ObjectMapper
+ * er satt opp til.
+ * <p>
+ * Inspirasjon for denne er henta frå <a href="https://github.com/swagger-api/swagger-core/issues/2784#issuecomment-388325057">...</a>
+ * <p>
+ * Fleire spesialiserte Schema klasser, for andre java.time.* typer kan legges til her seinare, ved behov.
  */
 public class TimeTypesModelConverter implements ModelConverter {
     private final ObjectMapper objectMapper;
@@ -39,6 +47,9 @@ public class TimeTypesModelConverter implements ModelConverter {
                 final Class<?> cls = javaType.getRawClass();
                 if(Duration.class.isAssignableFrom(cls)) {
                     return new DurationSchema();
+                }
+                if(YearMonth.class.isAssignableFrom(cls)) {
+                    return new YearMonthSchema();
                 }
             }
         }

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/models/YearMonthSchema.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/models/YearMonthSchema.java
@@ -1,0 +1,68 @@
+package no.nav.openapi.spec.utils.openapi.models;
+
+import io.swagger.v3.oas.models.SpecVersion;
+import io.swagger.v3.oas.models.media.Schema;
+import no.nav.openapi.spec.utils.openapi.TimeTypesModelConverter;
+
+import java.time.YearMonth;
+
+/**
+ * YearMonthSchema blir brukt av {@link TimeTypesModelConverter} for å sette korrekt openapi format for YearMonth typen.
+ * <p>
+ * Samme opplegg som {@link DurationSchema}
+ */
+public class YearMonthSchema extends Schema<YearMonth> {
+    public YearMonthSchema() {
+        this(SpecVersion.V30);
+    }
+
+    public YearMonthSchema(SpecVersion specVersion) {
+        super("string", "year-month", specVersion);
+    }
+
+    @Override
+    public YearMonthSchema format(String format) {
+        super.setFormat(format);
+        return this;
+    }
+
+    @Override
+    public YearMonthSchema _default(YearMonth _default) {
+        super.setDefault(_default);
+        return this;
+    }
+
+    @Override
+    protected YearMonth cast(Object value) {
+        if (value != null) {
+            if (value instanceof YearMonth) {
+                return (YearMonth) value;
+            } else if (value instanceof String) {
+                return YearMonth.parse((String) value);
+            } else {
+                throw new ClassCastException("Cannot cast " + value.getClass() + " to YearMonth");
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if(o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        return super.equals(o);
+    }
+
+    @Override
+    public String toString() {
+        final var sb = new StringBuilder();
+        sb.append("class YearMonthSchema {\n");
+        sb.append("    ").append(toIndentedString(super.toString())).append("\n");
+        sb.append("}");
+        return sb.toString();
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
@@ -1,6 +1,7 @@
 package no.nav.openapi.spec.utils.openapi;
 
 import java.time.Duration;
+import java.time.YearMonth;
 
 /**
  * Kun for bruk i OpenapiGenerateTest
@@ -10,4 +11,5 @@ public class DummyDto {
     public String tekstProperty;
     public DummyEnum enumProperty = DummyEnum.DUMMY_V1;
     public Duration durationProperty = Duration.parse("P20DT1H13S");
+    public YearMonth yearMonthProperty = YearMonth.parse("2023-10");
 }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
@@ -35,7 +35,7 @@ public class OpenapiGenerateTest {
         assertThat(schemas).containsKey("DummyDto");
         final var dummyDto = schemas.get("DummyDto");
         Map<String, Schema> properties = dummyDto.getProperties();
-        assertThat(properties).containsKeys("nummerProperty", "tekstProperty", "enumProperty", "durationProperty");
+        assertThat(properties).containsKeys("nummerProperty", "tekstProperty", "enumProperty", "durationProperty", "yearMonthProperty");
         assertThat(properties.get("nummerProperty").getType()).isEqualTo("integer");
         assertThat(properties.get("tekstProperty").getType()).isEqualTo("string");
         // Sjekk at reskriving til å ha enums som refs fungerte
@@ -56,6 +56,9 @@ public class OpenapiGenerateTest {
         }
         assertThat(properties.get("durationProperty").getType()).isEqualTo("string");
         assertThat(properties.get("durationProperty").getFormat()).isEqualTo("duration");
+
+        assertThat(properties.get("yearMonthProperty").getType()).isEqualTo("string");
+        assertThat(properties.get("yearMonthProperty").getFormat()).isEqualTo("year-month");
     }
 
     @Test


### PR DESCRIPTION
To get correct openapi spec generated for the java.time.YearMonth type. (string of format yyyy-mm)