### PR TITLE
fix: Ensure ordering of generated Schema(oneOf = ...) elements are stable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/OneOfSubtypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/OneOfSubtypesModelConverter.java
@@ -55,8 +55,9 @@ public class OneOfSubtypesModelConverter implements ModelConverter {
 
             @Override
             public Class<?>[] oneOf() {
-                final var ret = new Class<?>[oneOf.size()];
-                return oneOf.toArray(ret);
+                return oneOf.stream()
+                        .sorted((a, b) -> a.getCanonicalName().compareTo(b.getCanonicalName()))
+                        .toArray(Class<?>[]::new);
             }
 
             @Override

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
@@ -72,7 +72,7 @@ public class OpenapiGenerateTest {
         assertThat(dummyEnumValues).containsExactlyInAnyOrderElementsOf(Arrays.stream(DummyEnum.values()).map(v -> v.enumVerdi).toList());
         final var dummyEnumNames = dummyEnum.getExtensions().get("x-enum-varnames");
         if(dummyEnumNames instanceof String[] names) {
-            assertThat(names).containsExactlyInAnyOrderElementsOf(Arrays.stream(DummyEnum.values()).map(v -> v.name()).toList());
+            assertThat(names).containsExactlyElementsOf(Arrays.stream(DummyEnum.values()).map(v -> v.name()).toList());
         } else {
             fail();
         }
@@ -90,7 +90,7 @@ public class OpenapiGenerateTest {
             final var abstractClass = schemas.get(makeName.apply(SomeAbstractClass.class));
             final List<Schema> oneOf = abstractClass.getOneOf();
             final var refs = oneOf.stream().map(s -> s.get$ref()).toList();
-            assertThat(refs).containsExactlyInAnyOrder(componentRef(makeName.apply(SomeExtensionClassA.class)), componentRef(makeName.apply(SomeExtensionClassB.class)));
+            assertThat(refs).containsExactly(componentRef(makeName.apply(SomeExtensionClassA.class)), componentRef(makeName.apply(SomeExtensionClassB.class)));
         }
         {
             final var someExtensionClassA = schemas.get(makeName.apply(SomeExtensionClassA.class));


### PR DESCRIPTION
Otherwise the generated openapi spec json file randomly changes the order of the oneOf type names even though the source code has not changed.