### PR TITLE
Fix JsonSubTypes to Schema(oneOf = ..)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationCreator.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationCreator.java
@@ -1,47 +1,24 @@
 package no.nav.openapi.spec.utils.openapi;
 
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.databind.type.SimpleType;
-import io.swagger.v3.core.converter.AnnotatedType;
-import io.swagger.v3.core.converter.ModelConverter;
-import io.swagger.v3.core.converter.ModelConverterContext;
 import io.swagger.v3.oas.annotations.ExternalDocumentation;
 import io.swagger.v3.oas.annotations.StringToClassMapItem;
 import io.swagger.v3.oas.annotations.extensions.Extension;
 import io.swagger.v3.oas.annotations.media.DependentRequired;
 import io.swagger.v3.oas.annotations.media.DiscriminatorMapping;
-import io.swagger.v3.oas.models.media.Schema;
+
 
 import java.lang.annotation.Annotation;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
-/**
- * When the type to resolve is an abstract class without any @Schema annotation, and registeredSubtypes has one or more
- * classes that are subtypes of the type, this will automatically add a @Schema annotation with "oneOf" set to all
- * registered matching subtypes to the type to resolve. When it is then resolved further by the chain, this leads to
- * all matching subtypes being declared as possitble "oneOf" values.
- * <br>
- * Used so that we can avoid manually having to hardcode the @Schema(oneOf = ...) annotation.
- */
-// TODO Cleanup this. Consider if the replacement of JsonSubTypes to Schema(oneOf.. ) should be separate converter. Atleast naming etc needs to be looked at.
-// TODO Improve testing. One with registered subtypes, one with JsonSubTypes annotation declared, etc.
-public class OneOfSubtypesModelConverter implements ModelConverter {
-
-    final Set<Class<?>> registeredSubtypes;
-
-    public OneOfSubtypesModelConverter(final Set<Class<?>> registeredSubtypes) {
-        this.registeredSubtypes = registeredSubtypes;
-    }
-
+public class AnnotationCreator {
     /**
      * Programmatically creates an instance of swagger @Schema annotation with given oneOf value
      */
-    private static io.swagger.v3.oas.annotations.media.Schema createOneOfSchemaAnnotation(Set<Class<?>> oneOf) {
+    public static io.swagger.v3.oas.annotations.media.Schema createOneOfSchemaAnnotation(Set<Class<?>> oneOf) {
+        final var sortedOneOf = oneOf.stream()
+                .sorted((a, b) -> a.getCanonicalName().compareTo(b.getCanonicalName()))
+                .toArray(Class<?>[]::new);
+
         io.swagger.v3.oas.annotations.media.Schema schema = new io.swagger.v3.oas.annotations.media.Schema() {
             @Override
             public Class<?> implementation() {
@@ -55,9 +32,7 @@ public class OneOfSubtypesModelConverter implements ModelConverter {
 
             @Override
             public Class<?>[] oneOf() {
-                return oneOf.stream()
-                        .sorted((a, b) -> a.getCanonicalName().compareTo(b.getCanonicalName()))
-                        .toArray(Class<?>[]::new);
+                return sortedOneOf;
             }
 
             @Override
@@ -439,80 +414,4 @@ public class OneOfSubtypesModelConverter implements ModelConverter {
         return schema;
     }
 
-    private boolean hasNoSchemaAnnotation(final Annotation[] annotations) {
-        return annotations == null ||
-            Arrays.stream(annotations).noneMatch(annotation -> annotation instanceof io.swagger.v3.oas.annotations.media.Schema);
-    }
-
-    private Optional<JsonSubTypes> getSubTypesAnnotation(final Annotation[] annotations) {
-        if(annotations != null) {
-            return Arrays.stream(annotations).flatMap(annotation -> {
-                if (annotation instanceof JsonSubTypes jsonSubTypes) {
-                    return Stream.of(jsonSubTypes);
-                } else {
-                    return null;
-                }
-            }).findFirst();
-        }
-        return Optional.empty();
-    }
-
-    private static Stream<Annotation> annotationsWithoutJsonSubTypes(final Annotation[] annotations) {
-        return Arrays.stream(annotations).filter(annotation -> !(annotation instanceof JsonSubTypes));
-    }
-
-    private static Annotation[] firstNonEmptyAnnotations(final Annotation[] a, final Annotation[] b) {
-        if(a != null && a.length > 0) {
-            return a;
-        }
-        return b;
-    }
-
-    @Override
-    public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
-        if(chain.hasNext()) {
-            if(type.isResolveAsRef() ) {
-
-                if(type.getType() instanceof SimpleType simpleType) {
-                    final Class<?> cls = simpleType.getRawClass();
-                    // If type has resolved annotations already, use them. If not get them from class before next in chain resolves them.
-                    final var annotations = firstNonEmptyAnnotations(type.getCtxAnnotations(), cls.getAnnotations());
-                    if(hasNoSchemaAnnotation(annotations)) {
-                        if (simpleType.isAbstract() && !simpleType.isFinal()) {
-                            final var maybeSubTypesAnnotation = getSubTypesAnnotation(annotations);
-                            if(maybeSubTypesAnnotation.isPresent()) {
-                                // Replace @JsonSubTypes annotation with @Schema(oneOf = ...) annotation to get the openapi model we want.
-                                // Otherwise, if we end up with both @JsonSubTypes and @Schema(oneOf = ...) on the type, the resolved openapi
-                                // schema becomes problematic, with circular references (allOf on subtype, added in resolveSubTypes in ModelResolver).
-                                // Without @Schema(oneOf = ...) and just @JsonSubTypes, the resolved openapi schema does not become specific enough.
-                                final Set<Class<?>> subClasses = Arrays.stream(maybeSubTypesAnnotation.get().value()).map(jst -> jst.value()).collect(Collectors.toUnmodifiableSet());
-                                if(!subClasses.isEmpty()) {
-                                    final var schemaAnnotation = createOneOfSchemaAnnotation(subClasses);
-                                    // Replace @JsonSubTypes annotation with @Schema annotation
-                                    final Annotation[] typeAnnotations = Stream.concat(annotationsWithoutJsonSubTypes(annotations), Stream.of(schemaAnnotation)).toArray(Annotation[]::new);
-                                    return chain.next().resolve(type.ctxAnnotations(typeAnnotations), context, chain);
-                                }
-
-                            } else {
-                                // No @JsonSubTypes annotation present. Create @Schema(oneOf = ...) annotation from registeredSubTypes, if any there are matching.
-                                final var subclasses = registeredSubtypes.stream().filter(cls::isAssignableFrom).collect(Collectors.toUnmodifiableSet());
-                                if (!subclasses.isEmpty()) {
-                                    // resolve all subclasses, then set type to be oneOf all of them
-                                    final var schemaAnnotation = createOneOfSchemaAnnotation(subclasses);
-                                    // Create copy of existing annotations on type, add created schemaAnnotation to it
-                                    final Annotation[] typeAnnotations = Stream.concat(annotationsWithoutJsonSubTypes(annotations), Stream.of(schemaAnnotation)).toArray(Annotation[]::new);
-                                    //final var typeAnnotations = Arrays.copyOf(type.getCtxAnnotations(), type.getCtxAnnotations().length + 1);
-                                    typeAnnotations[typeAnnotations.length - 1] = schemaAnnotation;
-                                    return chain.next().resolve(type.ctxAnnotations(typeAnnotations), context, chain);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            return chain.next().resolve(type, context, chain);
-        } else {
-            return null;
-        }
-    }
 }

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
@@ -47,7 +47,7 @@ public class AnnotationUtils {
         final var list = new ArrayList<Annotation>(Arrays.asList(original));
         var replaced = false;
         for(var i = 0; i < list.size(); i++) {
-            if(list.get(i).getClass().equals(replacement.getClass())) {
+            if(list.get(i).annotationType().equals(replacement.annotationType())) {
                 list.set(i, replacement);
                 replaced = true;
             }

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
@@ -1,0 +1,62 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import io.swagger.v3.core.util.AnnotationsUtils;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class AnnotationUtils {
+
+    public static boolean hasOneOfSchema(final Annotation incoming) {
+        if(incoming instanceof io.swagger.v3.oas.annotations.media.Schema schema) {
+            return schema.oneOf() != null && schema.oneOf().length > 0;
+        } else if(incoming instanceof io.swagger.v3.oas.annotations.media.ArraySchema arraySchema) {
+            final var schema = arraySchema.schema();
+            return schema.oneOf() != null && schema.oneOf().length > 0;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Adds oneOfSchema content to incoming, unless the incoming Schema annotation already has the property set in oneOfSchema. Will do nothing then
+     */
+    public static Annotation mergeOneOfInto(final Annotation incoming, final io.swagger.v3.oas.annotations.media.Schema oneOfSchema) {
+        if(incoming == null) {
+            return oneOfSchema;
+        } else if(oneOfSchema == null) {
+            return incoming;
+        } else if(incoming instanceof io.swagger.v3.oas.annotations.media.Schema schema) {
+            return AnnotationsUtils.mergeSchemaAnnotations(schema, oneOfSchema);
+        } else if(incoming instanceof io.swagger.v3.oas.annotations.media.ArraySchema arraySchema) {
+            final var mergedSchema = AnnotationsUtils.mergeSchemaAnnotations(arraySchema.schema(), oneOfSchema);
+            return AnnotationsUtils.mergeArrayWithSchemaAnnotation(arraySchema, mergedSchema);
+        } else {
+            throw new IllegalArgumentException("incoming not instance of io.swagger.v3.oas.annotations.media.Schema or io.swagger.v3.oas.annotations.media.ArraySchema. Was: " + incoming.getClass().getCanonicalName() + ". Cannot merge oneOf Schema into it");
+        }
+    }
+
+    public static Annotation[] replaceSchemaOrArraySchemaAnnotation(final Annotation[] original, final Annotation replacement) {
+        if(replacement == null) {
+            return original;
+        }
+        if(original == null) {
+            return new Annotation[]{replacement};
+        }
+        final var list = new ArrayList<Annotation>(Arrays.asList(original));
+        var replaced = false;
+        for(var i = 0; i < list.size(); i++) {
+            if(list.get(i).getClass().equals(replacement.getClass())) {
+                list.set(i, replacement);
+                replaced = true;
+            }
+        }
+        if(!replaced) {
+            // Add it to end of list
+            list.add(replacement);
+        }
+        return list.toArray(new Annotation[]{});
+    }
+
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/AnnotationUtils.java
@@ -1,5 +1,6 @@
 package no.nav.openapi.spec.utils.openapi;
 
+import com.fasterxml.jackson.databind.type.SimpleType;
 import io.swagger.v3.core.util.AnnotationsUtils;
 
 import java.lang.annotation.Annotation;
@@ -58,5 +59,23 @@ public class AnnotationUtils {
         }
         return list.toArray(new Annotation[]{});
     }
+
+    /**
+     * Resolves Schema annotation from incoming ctxAnnotations and/or the given type.
+     * If the incomingCtxAnnotations are equal to the newResolved, return incomingCtxAnnotations, to avoid creating new
+     * objects, that cause stackoverflow in the context.resolve code.
+     */
+    public static Annotation resolveIncomingSchemaAnnotation(final Annotation[] incomingCtxAnnotations, final SimpleType simpleType) {
+        final var newResolved = AnnotationsUtils.mergeSchemaAnnotations(incomingCtxAnnotations, simpleType, false);
+        Annotation incomingCtxSchemaAnnotation = AnnotationsUtils.getSchemaAnnotation(incomingCtxAnnotations);
+        if(incomingCtxSchemaAnnotation == null) {
+            incomingCtxSchemaAnnotation = AnnotationsUtils.getArraySchemaAnnotation(incomingCtxAnnotations);
+        }
+        if(incomingCtxSchemaAnnotation != null && AnnotationsUtils.equals(incomingCtxSchemaAnnotation, newResolved)){
+            return incomingCtxSchemaAnnotation;
+        }
+        return newResolved;
+    }
+
 
 }

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
@@ -61,7 +61,7 @@ public class JsonSubTypesModelConverter implements ModelConverter {
             if(type.isResolveAsRef() ) {
                 if(type.getType() instanceof SimpleType simpleType) {
                     final Class<?> cls = simpleType.getRawClass();
-                    final var incomingSchemaAnnotation = AnnotationsUtils.mergeSchemaAnnotations(type.getCtxAnnotations(), simpleType, true);
+                    final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
                     if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
                         // If class has @JsonSubTypes annotation, create @Schema(oneOf = ...) based on it and add it to type.ctxAnnotations
                         final var jsonSubtypesAnnotation = cls.getDeclaredAnnotation(JsonSubTypes.class);

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
@@ -1,0 +1,83 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.AnnotationsUtils;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * When the type to resolve has @JsonSubTypes annotation, add a @Schema(oneOf = ...) annotation with the subtypes declared
+ * in the @JsonSubTypes to the ctxAnnotations on it.
+ * <p>
+ * The base ModelResolver called last in the chain will then add desired oneOf elements for all the declare subtypes, and
+ * we avoid the default behaviour of @JsonSubTypes, which is to also add the allOf schema element on the subtypes.
+ * <p>
+ * <b>NB:</b> For this to work as intended, the ObjectMapper used by ModelResolver must be set up with the
+ * #{@link NoJsonSubTypesAnnotationIntrospector}. Otherwise the base ModelResolver will still add allOf element on subtypes.
+ */
+public class JsonSubTypesModelConverter implements ModelConverter {
+
+    public JsonSubTypesModelConverter() {
+    }
+
+    private Optional<JsonSubTypes> getSubTypesAnnotation(final Annotation[] annotations) {
+        if(annotations != null) {
+            return Arrays.stream(annotations).flatMap(annotation -> {
+                if (annotation instanceof JsonSubTypes jsonSubTypes) {
+                    return Stream.of(jsonSubTypes);
+                } else {
+                    return null;
+                }
+            }).findFirst();
+        }
+        return Optional.empty();
+    }
+
+    private static Stream<Annotation> annotationsWithoutJsonSubTypes(final Annotation[] annotations) {
+        return Arrays.stream(annotations).filter(annotation -> !(annotation instanceof JsonSubTypes));
+    }
+
+    private static Annotation[] firstNonEmptyAnnotations(final Annotation[] a, final Annotation[] b) {
+        if(a != null && a.length > 0) {
+            return a;
+        }
+        return b;
+    }
+
+    @Override
+    public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        if(chain.hasNext()) {
+            if(type.isResolveAsRef() ) {
+                if(type.getType() instanceof SimpleType simpleType) {
+                    final Class<?> cls = simpleType.getRawClass();
+                    final var incomingSchemaAnnotation = AnnotationsUtils.mergeSchemaAnnotations(type.getCtxAnnotations(), simpleType, true);
+                    if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
+                        // If class has @JsonSubTypes annotation, create @Schema(oneOf = ...) based on it and add it to type.ctxAnnotations
+                        final var jsonSubtypesAnnotation = cls.getDeclaredAnnotation(JsonSubTypes.class);
+                        if (jsonSubtypesAnnotation != null) {
+                            final Set<Class<?>> subClasses = Arrays.stream(jsonSubtypesAnnotation.value()).map(jst -> jst.value()).collect(Collectors.toUnmodifiableSet());
+                            final var oneOfSchema = subClasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subClasses);
+                            final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
+                            final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
+                            return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
+                        }
+                    }
+                }
+            }
+            return chain.next().resolve(type, context, chain);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
@@ -13,7 +13,7 @@ import java.util.stream.Collectors;
  * When the type to resolve is an abstract class without any @Schema annotation, and registeredSubtypes has one or more
  * classes that are subtypes of the type, this will automatically add a @Schema annotation with "oneOf" set to all
  * registered matching subtypes to the type to resolve. When it is then resolved further by the chain, this leads to
- * all matching subtypes being declared as possitble "oneOf" values.
+ * all matching subtypes being declared as possible "oneOf" values.
  * <br>
  * Used so that we can avoid manually having to hardcode the @Schema(oneOf = ...) annotation.
  */
@@ -32,7 +32,6 @@ public class RegisteredSubtypesModelConverter implements ModelConverter {
                     if (simpleType.isAbstract() && !simpleType.isFinal()) { // Only add registeredSubtypes to abstract non-final types
                         final Class<?> cls = simpleType.getRawClass();
                         // Resolve current schema annotation from context (if set there) and type.
-                        // contextWins is not used in the base ModelResolver, but think it is correct to use here.
                         final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
                         if (!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
                             // Create schema with oneOf for the current type based on registeredSubTypes

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
@@ -1,0 +1,52 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import com.fasterxml.jackson.databind.type.SimpleType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.AnnotationsUtils;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * When the type to resolve is an abstract class without any @Schema annotation, and registeredSubtypes has one or more
+ * classes that are subtypes of the type, this will automatically add a @Schema annotation with "oneOf" set to all
+ * registered matching subtypes to the type to resolve. When it is then resolved further by the chain, this leads to
+ * all matching subtypes being declared as possitble "oneOf" values.
+ * <br>
+ * Used so that we can avoid manually having to hardcode the @Schema(oneOf = ...) annotation.
+ */
+public class RegisteredSubtypesModelConverter implements ModelConverter {
+    final Set<Class<?>> registeredSubtypes;
+
+    public RegisteredSubtypesModelConverter(final Set<Class<?>> registeredSubtypes) {
+        this.registeredSubtypes = registeredSubtypes;
+    }
+
+    @Override
+    public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        if(chain.hasNext()) {
+            if(type.isResolveAsRef() ) {
+                if(type.getType() instanceof SimpleType simpleType) {
+                    final Class<?> cls = simpleType.getRawClass();
+                    // Resolve current schema annotation from context (if set there) and type.
+                    // contextWins is not used in the base ModelResolver, but think it is correct to use here.
+                    final var incomingSchemaAnnotation = AnnotationsUtils.mergeSchemaAnnotations(type.getCtxAnnotations(), simpleType, true);
+                    if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
+                        // Create schema with oneOf for the current type based on registeredSubTypes
+                        final var subclasses = registeredSubtypes.stream().filter(cls::isAssignableFrom).collect(Collectors.toUnmodifiableSet());
+                        final var oneOfSchema = subclasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subclasses);
+                        final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
+                        final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
+                        return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
+                    }
+                }
+            }
+            return chain.next().resolve(type, context, chain);
+        } else {
+            return null;
+        }
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.type.SimpleType;
 import io.swagger.v3.core.converter.AnnotatedType;
 import io.swagger.v3.core.converter.ModelConverter;
 import io.swagger.v3.core.converter.ModelConverterContext;
-import io.swagger.v3.core.util.AnnotationsUtils;
 import io.swagger.v3.oas.models.media.Schema;
 
 import java.util.*;
@@ -33,7 +32,7 @@ public class RegisteredSubtypesModelConverter implements ModelConverter {
                     final Class<?> cls = simpleType.getRawClass();
                     // Resolve current schema annotation from context (if set there) and type.
                     // contextWins is not used in the base ModelResolver, but think it is correct to use here.
-                    final var incomingSchemaAnnotation = AnnotationsUtils.mergeSchemaAnnotations(type.getCtxAnnotations(), simpleType, true);
+                    final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
                     if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
                         // Create schema with oneOf for the current type based on registeredSubTypes
                         final var subclasses = registeredSubtypes.stream().filter(cls::isAssignableFrom).collect(Collectors.toUnmodifiableSet());

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/AbstractWithSchema.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/AbstractWithSchema.java
@@ -1,0 +1,8 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "this abstract class has a schema annotation")
+public abstract class AbstractWithSchema {
+    public String superWithSchema = "ok";
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ActualWithSchema.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ActualWithSchema.java
@@ -1,0 +1,5 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+public class ActualWithSchema extends AbstractWithSchema {
+    public String actually = "actually";
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherAbstractClass.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherAbstractClass.java
@@ -1,0 +1,13 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "typename")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = OtherExtensionClassA.class, name = "a"),
+        @JsonSubTypes.Type(value = OtherExtensionClassB.class, name = "b")
+})
+public abstract class OtherAbstractClass {
+    public String infoOnSuperClass = "someInfoOnOtherAbstractClass";
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherData.java
@@ -1,5 +1,8 @@
 package no.nav.openapi.spec.utils.jackson.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "description of other data, tests stackoveflow issue that was does not reappear")
 public record OtherData(
         String txt1,
         int num1,

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassA.java
@@ -1,0 +1,5 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+public class OtherExtensionClassA extends OtherAbstractClass {
+    public String otherExtensionA = "otherExtensionA";
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassB.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassB.java
@@ -1,0 +1,5 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+public class OtherExtensionClassB extends OtherAbstractClass {
+    public String otherExtensionB = "otherExtensionB";
+}

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
@@ -1,7 +1,6 @@
 package no.nav.openapi.spec.utils.openapi;
 
-import no.nav.openapi.spec.utils.jackson.dto.SomeAbstractClass;
-import no.nav.openapi.spec.utils.jackson.dto.SomeExtensionClassA;
+import no.nav.openapi.spec.utils.jackson.dto.*;
 
 import java.time.Duration;
 import java.time.YearMonth;
@@ -15,9 +14,11 @@ public class DummyDto {
     public DummyEnum enumProperty = DummyEnum.DUMMY_V1;
     public Duration durationProperty = Duration.parse("P20DT1H13S");
     public YearMonth yearMonthProperty = YearMonth.parse("2023-10");
-//  OneOfSubtypesModelConverter will autopmatically create @Schema annotation as declared below, since SomeExtensionClassX
+//  RegisteredSubtypesModelConverter will autopmatically create @Schema annotation as declared below, since SomeExtensionClassX
 //  is added to OpenApiSetupHelper registeredSubTypes. This is therefore commented out here just to show what would otherwise
 //  be needed:
 //  @Schema(oneOf = {SomeExtensionClassA.class, SomeExtensionClassB.class})
     public SomeAbstractClass abstractClass = new SomeExtensionClassA();
+    // Test of inheritance annotated with JsonSubTypes for all subtypes.
+    public OtherAbstractClass otherAbstractClass = new OtherExtensionClassA();
 }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyRestService.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyRestService.java
@@ -4,6 +4,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import no.nav.openapi.spec.utils.jackson.dto.AbstractWithSchema;
+import no.nav.openapi.spec.utils.jackson.dto.ActualWithSchema;
 import no.nav.openapi.spec.utils.jackson.dto.OtherData;
 
 /**
@@ -21,9 +23,9 @@ public class DummyRestService {
     }
 
     @POST
-    @Path("/other")
+    @Path("/abstract")
     @Operation(description = "reproduction of resolve loop issue")
-    public OtherData other() {
-        return new OtherData("", 1, 2);
+    public AbstractWithSchema other() {
+        return new ActualWithSchema();
     }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyRestService.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyRestService.java
@@ -2,7 +2,9 @@ package no.nav.openapi.spec.utils.openapi;
 
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
+import no.nav.openapi.spec.utils.jackson.dto.OtherData;
 
 /**
  * Kun for bruk i OpenapiGenerateTest
@@ -16,5 +18,12 @@ public class DummyRestService {
     @Operation(description = "returns dummy dto")
     public DummyDto dummy() {
         return new DummyDto();
+    }
+
+    @POST
+    @Path("/other")
+    @Operation(description = "reproduction of resolve loop issue")
+    public OtherData other() {
+        return new OtherData("", 1, 2);
     }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
@@ -30,7 +30,7 @@ public class OpenapiGenerateTest {
         final var setupHelper = new OpenApiSetupHelper(new DummyApplication(), new Info(), new Server());
         setupHelper.addResourcePackage("no.nav.openapi.spec.utils"); // Prevents scanner from including classes outside this package
         setupHelper.addResourceClass(DummyRestService.class.getCanonicalName());
-        setupHelper.registerSubTypes(Set.of(SomeExtensionClassB.class, SomeExtensionClassA.class));
+        setupHelper.registerSubTypes(Set.of(SomeExtensionClassB.class, SomeExtensionClassA.class)); // ActualWithSchema.class deliberately not registered here.
         if(stripTypeNamePrefixes) {
             setupHelper.setTypeNameResolver(new PrefixStrippingFQNTypeNameResolver(STRIP_TYPE_NAME_PREFIX));
         }

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/OpenapiGenerateTest.java
@@ -6,9 +6,7 @@ import io.swagger.v3.oas.models.Paths;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
-import no.nav.openapi.spec.utils.jackson.dto.SomeAbstractClass;
-import no.nav.openapi.spec.utils.jackson.dto.SomeExtensionClassA;
-import no.nav.openapi.spec.utils.jackson.dto.SomeExtensionClassB;
+import no.nav.openapi.spec.utils.jackson.dto.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -95,6 +93,18 @@ public class OpenapiGenerateTest {
         {
             final var someExtensionClassA = schemas.get(makeName.apply(SomeExtensionClassA.class));
             assertThat(someExtensionClassA.getAllOf()).isNull();
+        }
+        // Check that otherAbstractClass has oneOf set as desired
+        assertThat(properties.get("otherAbstractClass").get$ref()).isEqualTo(componentRef(makeName.apply(OtherAbstractClass.class)));
+        {
+            final var otherAbstractClass = schemas.get(makeName.apply(OtherAbstractClass.class));
+            final List<Schema> oneOf = otherAbstractClass.getOneOf();
+            final var refs = oneOf.stream().map(s -> s.get$ref()).toList();
+            assertThat(refs).containsExactly(componentRef(makeName.apply(OtherExtensionClassA.class)), componentRef(makeName.apply(OtherExtensionClassB.class)));
+        }
+        {
+            final var otherExtensionClassA = schemas.get(makeName.apply(OtherExtensionClassA.class));
+            assertThat(otherExtensionClassA.getAllOf()).isNull();
         }
     }
 


### PR DESCRIPTION
The conversion of JsonSubTypes to Schema(oneOf = ...) did not work as intended.

Altso there was a non-ending recursion occurring, causing stackoverflow if the type processed had a Schema annotation (without oneOf). 