### PR TITLE
Bugfix not ref resolve

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>2.0.2</version>
+    <version>2.0.3</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
@@ -58,20 +58,18 @@ public class JsonSubTypesModelConverter implements ModelConverter {
     @Override
     public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
         if(chain.hasNext()) {
-            if(type.isResolveAsRef() ) {
-                if(type.getType() instanceof SimpleType simpleType) {
-                    final Class<?> cls = simpleType.getRawClass();
-                    final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
-                    if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
-                        // If class has @JsonSubTypes annotation, create @Schema(oneOf = ...) based on it and add it to type.ctxAnnotations
-                        final var jsonSubtypesAnnotation = cls.getDeclaredAnnotation(JsonSubTypes.class);
-                        if (jsonSubtypesAnnotation != null) {
-                            final Set<Class<?>> subClasses = Arrays.stream(jsonSubtypesAnnotation.value()).map(jst -> jst.value()).collect(Collectors.toUnmodifiableSet());
-                            final var oneOfSchema = subClasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subClasses);
-                            final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
-                            final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
-                            return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
-                        }
+            if(type.getType() instanceof SimpleType simpleType) {
+                final Class<?> cls = simpleType.getRawClass();
+                final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
+                if(!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
+                    // If class has @JsonSubTypes annotation, create @Schema(oneOf = ...) based on it and add it to type.ctxAnnotations
+                    final var jsonSubtypesAnnotation = cls.getDeclaredAnnotation(JsonSubTypes.class);
+                    if (jsonSubtypesAnnotation != null) {
+                        final Set<Class<?>> subClasses = Arrays.stream(jsonSubtypesAnnotation.value()).map(jst -> jst.value()).collect(Collectors.toUnmodifiableSet());
+                        final var oneOfSchema = subClasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subClasses);
+                        final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
+                        final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
+                        return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
                     }
                 }
             }

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/JsonSubTypesModelConverter.java
@@ -31,30 +31,6 @@ public class JsonSubTypesModelConverter implements ModelConverter {
     public JsonSubTypesModelConverter() {
     }
 
-    private Optional<JsonSubTypes> getSubTypesAnnotation(final Annotation[] annotations) {
-        if(annotations != null) {
-            return Arrays.stream(annotations).flatMap(annotation -> {
-                if (annotation instanceof JsonSubTypes jsonSubTypes) {
-                    return Stream.of(jsonSubTypes);
-                } else {
-                    return null;
-                }
-            }).findFirst();
-        }
-        return Optional.empty();
-    }
-
-    private static Stream<Annotation> annotationsWithoutJsonSubTypes(final Annotation[] annotations) {
-        return Arrays.stream(annotations).filter(annotation -> !(annotation instanceof JsonSubTypes));
-    }
-
-    private static Annotation[] firstNonEmptyAnnotations(final Annotation[] a, final Annotation[] b) {
-        if(a != null && a.length > 0) {
-            return a;
-        }
-        return b;
-    }
-
     @Override
     public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
         if(chain.hasNext()) {

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/RegisteredSubtypesModelConverter.java
@@ -27,20 +27,18 @@ public class RegisteredSubtypesModelConverter implements ModelConverter {
     @Override
     public Schema<?> resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
         if(chain.hasNext()) {
-            if(type.isResolveAsRef() ) {
-                if(type.getType() instanceof SimpleType simpleType) {
-                    if (simpleType.isAbstract() && !simpleType.isFinal()) { // Only add registeredSubtypes to abstract non-final types
-                        final Class<?> cls = simpleType.getRawClass();
-                        // Resolve current schema annotation from context (if set there) and type.
-                        final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
-                        if (!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
-                            // Create schema with oneOf for the current type based on registeredSubTypes
-                            final var subclasses = registeredSubtypes.stream().filter(cls::isAssignableFrom).collect(Collectors.toUnmodifiableSet());
-                            final var oneOfSchema = subclasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subclasses);
-                            final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
-                            final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
-                            return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
-                        }
+            if(type.getType() instanceof SimpleType simpleType) {
+                if (simpleType.isAbstract() && !simpleType.isFinal()) { // Only add registeredSubtypes to abstract non-final types
+                    final Class<?> cls = simpleType.getRawClass();
+                    // Resolve current schema annotation from context (if set there) and type.
+                    final var incomingSchemaAnnotation = AnnotationUtils.resolveIncomingSchemaAnnotation(type.getCtxAnnotations(), simpleType);
+                    if (!AnnotationUtils.hasOneOfSchema(incomingSchemaAnnotation)) {
+                        // Create schema with oneOf for the current type based on registeredSubTypes
+                        final var subclasses = registeredSubtypes.stream().filter(cls::isAssignableFrom).collect(Collectors.toUnmodifiableSet());
+                        final var oneOfSchema = subclasses.isEmpty() ? null : AnnotationCreator.createOneOfSchemaAnnotation(subclasses);
+                        final var outgoingSchema = AnnotationUtils.mergeOneOfInto(incomingSchemaAnnotation, oneOfSchema);
+                        final var newCtxAnnotations = AnnotationUtils.replaceSchemaOrArraySchemaAnnotation(type.getCtxAnnotations(), outgoingSchema);
+                        return chain.next().resolve(type.ctxAnnotations(newCtxAnnotations), context, chain);
                     }
                 }
             }


### PR DESCRIPTION
Some types annotated with JsonSubTypes were resolved without being marked to be resolved as refs. The JsonSubTypesModelResolver did then not do it's intended work.

Fixes this, and removes the if check for resolve as ref in RegisteredSubTypesModelResolver too, since we probably want the the same behaviour there.