### PR TITLE
Discriminator fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/DiscriminatorModelConverter.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/DiscriminatorModelConverter.java
@@ -1,0 +1,167 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.type.SimpleType;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.util.RefUtils;
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * DiscriminatorModelConverter adds discriminator property and discriminator mapping when it is missing on types that has been
+ * resolved with a non-empty oneOf property.
+ * <p>
+ * To do this it must map from the resolved oneOf schema ref back to the class it originated from, to get its class name
+ * or @JsonTypeName annotations. Therefore, it maintains a lookup map of this where it adds the class type of all resolved
+ * schemas with a name.
+ */
+public class DiscriminatorModelConverter implements ModelConverter {
+    private RefToClassLookup classLookup;
+
+    public DiscriminatorModelConverter(final RefToClassLookup classLookup) {
+        this.classLookup = classLookup;
+    }
+
+    private JsonTypeInfo getJsonTypeInfo(final SimpleType simpleType) {
+        // get @JsonTypeInfo annotation from the class. If there is none, throw
+        final Class<?> cls = simpleType.getRawClass();
+        final JsonTypeInfo jsonTypeInfo = cls.getAnnotation(JsonTypeInfo.class);
+        if(jsonTypeInfo == null) {
+            throw new IllegalArgumentException("superClass " + cls.getCanonicalName() + " has no @JsonTypeInfo annotation. This is required to determine subtype discriminator");
+        }
+        // For now we only support use = Id.CLASS and use = Id.NAME. Don't think others are used in our codebase.
+        final boolean useClassOrNameDiscriminator = jsonTypeInfo.use() == JsonTypeInfo.Id.CLASS || jsonTypeInfo.use() == JsonTypeInfo.Id.NAME;
+        if(!useClassOrNameDiscriminator) {
+            throw new IllegalArgumentException("superClass " + cls.getCanonicalName() + " has unsupported @JsonTypeInfo(use = "+ jsonTypeInfo.use()+" ) value");
+        }
+        return jsonTypeInfo;
+    }
+
+    protected String resolveDiscriminatorProperty(final JsonTypeInfo jsonTypeInfo) {
+        // Determine what to set discriminatorProperty to base on @JsonTypeInfo.
+        // Note: If we are to support other include options than PROPERTY, this might need changing.
+        // if the property value on annotation is set, use that. Else, use the value from the use value.
+        final var property = jsonTypeInfo.property();
+        if(property != null && !property.isBlank()) {
+            return property;
+        }
+        else {
+            return jsonTypeInfo.use().getDefaultPropertyName();
+        }
+    }
+
+    // A JsonSubType.Type annotation can have several names set for the same class, so this returns a Set.
+    protected SortedSet<String> resolveJsonSubTypeNames(final JsonSubTypes jsonSubTypes, final Class<?> subClass) {
+        if(jsonSubTypes != null) {
+            // Find the Type annotation for given subClass, if there is one.
+            final Stream<JsonSubTypes.Type> maybeJsonSubType = Arrays.stream(jsonSubTypes.value()).filter(v -> v.value().equals(subClass));
+            // Find name or names value, if defined
+            final Stream<String> names = maybeJsonSubType.flatMap(typ -> {
+                final var typeNames = typ.names();
+                if (typeNames != null && typeNames.length > 0) {
+                    return Stream.of(typeNames);
+                }
+                final var typeName = typ.name();
+                if (typeName != null && !typeName.isBlank()) {
+                    return Stream.of(typeName);
+                }
+                return Stream.empty();
+            });
+            return names.collect(Collectors.toCollection(TreeSet::new));
+        }
+        return new TreeSet<String>();
+    }
+
+    // Resolves name from @JsonTypeName annotation on subClass
+    // Returns SortedSet to match return type from resolveJsonSubTypeNames
+    protected SortedSet<String> resolveJsonTypeName(final Class<?> subClass) {
+        final var ret = new TreeSet<String>();
+        final JsonTypeName jsonTypeName = subClass.getDeclaredAnnotation(JsonTypeName.class);
+        if (jsonTypeName != null && jsonTypeName.value() != null && !jsonTypeName.value().isBlank()) {
+            ret.add(jsonTypeName.value());
+        }
+        return ret;
+    }
+
+
+    protected void fixDiscriminator(final SimpleType simpleType, final Schema superSchema) {
+        // If resolved schema has oneOf set, it should also have a discriminator.
+        final List<Schema> oneOf = superSchema.getOneOf();
+        if (oneOf != null && !oneOf.isEmpty()) {
+            Discriminator discriminator = superSchema.getDiscriminator();
+            if(discriminator == null) {
+                discriminator = new Discriminator();
+                superSchema.setDiscriminator(discriminator);
+            }
+            final JsonTypeInfo jsonTypeInfo = getJsonTypeInfo(simpleType);
+            if(discriminator.getPropertyName() == null || discriminator.getPropertyName().isBlank()) {
+                discriminator.setPropertyName(resolveDiscriminatorProperty(jsonTypeInfo));
+            }
+            // Resolve discriminator mapping if needed. One for each type in the oneOf list
+            final JsonSubTypes jsonSubTypes = simpleType.getRawClass().getDeclaredAnnotation(JsonSubTypes.class);
+            for(final Schema subClassSchema : oneOf) {
+                // Note: If we are to support other values than use = Id.NAME or use = Id.CLASS, this might need changing.
+                // A Discriminator mapping is needed when discriminator field value does not match the schema name or ref.
+                if(jsonTypeInfo.use() == JsonTypeInfo.Id.CLASS) {
+                    // it probably does not when use == Id.CLASS. We must then map from the fully qualified class name of
+                    // the subClass to the schema ref.
+                    final var subClass = this.classLookup.get(subClassSchema.get$ref());
+                    if(subClass != null) {
+                        discriminator.mapping(subClass.getCanonicalName(), subClassSchema.get$ref());
+                    }
+                } else if (jsonTypeInfo.use() == JsonTypeInfo.Id.NAME) {
+                    final var subClass = this.classLookup.get(subClassSchema.get$ref());
+                    if(subClass != null) {
+                        // If use == Id.NAME, two known cases require creating a mapping:
+                        // 1: The super type class is annotated with @JsonSubTypes, in which the @JsonSubTypes.Type annotation for the subtype has a name property determining the discriminator property value to use for it.
+                        // 2: The subClass is annotated with @JsonTypeName annotation which determines the discriminator property value to use for it.
+                        var discriminatorKeyValues = resolveJsonSubTypeNames(jsonSubTypes, subClass);
+                        if(discriminatorKeyValues.isEmpty()) { // @JsonTypeName only takes effect if @JsonSubTypes.Type name or names is not set
+                            discriminatorKeyValues = resolveJsonTypeName(subClass);
+                        }
+                        for(final var discriminatorKeyValue : discriminatorKeyValues) {
+                            discriminator.mapping(discriminatorKeyValue, subClassSchema.get$ref());
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        if(chain.hasNext()) {
+            final Schema resolved = chain.next().resolve(type, context, chain);
+            if(resolved != null) {
+                final String ref = Optional.ofNullable(resolved.get$ref()).orElse(RefUtils.constructRef(resolved.getName()));
+                // Resolved Schema must have name set for us to do anything useful with it.
+                final boolean resolvedHasName = resolved.getName() != null && !resolved.getName().isBlank();
+                if(type.getType() instanceof SimpleType simpleType) {
+                    if(resolvedHasName) {
+                        final Class<?> cls = simpleType.getRawClass();
+                        this.classLookup.put(ref, cls);
+                    }
+
+                    // Get the actual Schema when the returned resolved is a ref to it.
+                    final Schema resolvedOrReferenced = resolved.get$ref() != null ?
+                            context.getDefinedModels().get(RefUtils.extractSimpleName(resolved.get$ref()).getKey()) :
+                            resolved;
+
+                    fixDiscriminator(simpleType, resolvedOrReferenced);
+                } else if(type.getType() instanceof Class<?> cls && resolvedHasName) {
+                    this.classLookup.put(ref, cls);
+                }
+            }
+            return resolved;
+        }
+        return null;
+    }
+}

--- a/src/main/java/no/nav/openapi/spec/utils/openapi/RefToClassLookup.java
+++ b/src/main/java/no/nav/openapi/spec/utils/openapi/RefToClassLookup.java
@@ -1,0 +1,16 @@
+package no.nav.openapi.spec.utils.openapi;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class RefToClassLookup {
+    private Map<String, Class<?>> refToClassMap = new ConcurrentHashMap<>();
+
+    public void put(final String ref, final Class<?> cls) {
+        this.refToClassMap.put(ref, cls);
+    }
+
+    public Class<?> get(final String ref) {
+        return this.refToClassMap.get(ref);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
@@ -1,0 +1,101 @@
+package no.nav.openapi.spec.utils.jackson;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.ObjectMapperFactory;
+import no.nav.openapi.spec.utils.jackson.dto.*;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SubtypeObjectMappingTest {
+
+    private final ObjectMapper om;
+
+    public SubtypeObjectMappingTest() {
+        final var modifier = OpenapiCompatObjectMapperModifier.withDefaultModifications();
+        this.om = modifier.modify(ObjectMapperFactory.createJson());
+        this.om.registerSubtypes(ThirdExtensionClassA.class, ThirdExtensionClassB.class);
+    }
+
+    @Test
+    public void testDeSerializationThirdSuper() throws IOException {
+        final var reader = this.om.reader();
+        {
+            final var a = new ThirdExtensionClassA();
+            { // Do a roundtrip from subtype to serialized form and back to supertype that is instance of subtype
+                final var serialized = this.om.writeValueAsString(a);
+                final ThirdSuperClass deserialized = reader.readValue(serialized, ThirdSuperClass.class);
+                assertThat(deserialized).isInstanceOf(ThirdExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+            {
+                final var serializedFromTs = "{\"propertyA\":\"AAA\",\"superInfo\":\"superInfo\",\"@type\":\"KODE_A\"}";
+                final ThirdSuperClass deserialized = reader.readValue(serializedFromTs, ThirdSuperClass.class);
+                assertThat(deserialized).isInstanceOf(ThirdExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+        }
+        {
+            final var b = new ThirdExtensionClassB();
+            { // Do a roundtrip from subtype to serialized form and back to supertype that is instance of subtype
+                final var serialized = this.om.writeValueAsString(b);
+                final ThirdSuperClass deserialized = reader.readValue(serialized, ThirdSuperClass.class);
+                assertThat(deserialized).isInstanceOf(ThirdExtensionClassB.class);
+                assertThat(deserialized).isEqualTo(b);
+            }
+            {
+                final var serializedFromTs = "{\"propertyB\":\"BBB\",\"superInfo\":\"superInfo\",\"@type\":\"KODE_B\"}";
+                final ThirdSuperClass deserialized = reader.readValue(serializedFromTs, ThirdSuperClass.class);
+                assertThat(deserialized).isInstanceOf(ThirdExtensionClassB.class);
+                assertThat(deserialized).isEqualTo(b);
+            }
+        }
+    }
+
+    @Test
+    public void testDeSerializationOtherAbstractClass() throws IOException {
+        final var reader = this.om.reader();
+        {
+            final var a = new OtherExtensionClassA();
+            {
+                final var serialized = this.om.writeValueAsString(a);
+                final OtherAbstractClass deserialized = reader.readValue(serialized, OtherAbstractClass.class);
+                assertThat(deserialized).isInstanceOf(OtherExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+            {
+                final var serializedFromTs = "{\"otherExtensionA\":\"otherExtensionA\",\"infoOnSuperClass\":\"someInfoOnOtherAbstractClass\",\"typename\":\"a\"}";
+                final OtherAbstractClass deserialized = reader.readValue(serializedFromTs, OtherAbstractClass.class);
+                assertThat(deserialized).isInstanceOf(OtherExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+                final var serializedWithAlternativeTypename = "{\"otherExtensionA\":\"otherExtensionA\",\"infoOnSuperClass\":\"someInfoOnOtherAbstractClass\",\"typename\":\"a2\"}";
+                final OtherAbstractClass deserializedFromAlternativeTypename = reader.readValue(serializedWithAlternativeTypename, OtherAbstractClass.class);
+                assertThat(deserializedFromAlternativeTypename).isInstanceOf(OtherExtensionClassA.class);
+                assertThat(deserializedFromAlternativeTypename).isEqualTo(deserialized);
+            }
+        }
+    }
+
+    @Test
+    public void testDeSerializationSomeAbstractClass() throws IOException {
+        final var reader = this.om.reader();
+        {
+            final var a = new SomeExtensionClassA();
+            {
+                final var serialized = this.om.writeValueAsString(a);
+                final SomeAbstractClass deserialized = reader.readValue(serialized, SomeAbstractClass.class);
+                assertThat(deserialized).isInstanceOf(SomeExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+            {
+                final var serializedFromTs = "{\"infoOnSuperClass\":\"someInfoOnAbstractSuperClass\",\"extensionA\":\"extensionA\",\"cls\":\"no.nav.openapi.spec.utils.jackson.dto.SomeExtensionClassA\"}";
+                final SomeAbstractClass deserialized = reader.readValue(serializedFromTs, SomeAbstractClass.class);
+                assertThat(deserialized).isInstanceOf(SomeExtensionClassA.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+        }
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherAbstractClass.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherAbstractClass.java
@@ -3,11 +3,24 @@ package no.nav.openapi.spec.utils.jackson.dto;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
+import java.util.Objects;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "typename")
 @JsonSubTypes({
-        @JsonSubTypes.Type(value = OtherExtensionClassA.class, name = "a"),
+        @JsonSubTypes.Type(value = OtherExtensionClassA.class, names = {"a", "a2"}),
         @JsonSubTypes.Type(value = OtherExtensionClassB.class, name = "b")
 })
 public abstract class OtherAbstractClass {
     public String infoOnSuperClass = "someInfoOnOtherAbstractClass";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OtherAbstractClass that)) return false;
+        return Objects.equals(infoOnSuperClass, that.infoOnSuperClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(infoOnSuperClass);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassA.java
@@ -1,5 +1,19 @@
 package no.nav.openapi.spec.utils.jackson.dto;
 
+import java.util.Objects;
+
 public class OtherExtensionClassA extends OtherAbstractClass {
     public String otherExtensionA = "otherExtensionA";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OtherExtensionClassA that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(otherExtensionA, that.otherExtensionA);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), otherExtensionA);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassB.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/OtherExtensionClassB.java
@@ -1,5 +1,19 @@
 package no.nav.openapi.spec.utils.jackson.dto;
 
+import java.util.Objects;
+
 public class OtherExtensionClassB extends OtherAbstractClass {
     public String otherExtensionB = "otherExtensionB";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof OtherExtensionClassB that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(otherExtensionB, that.otherExtensionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), otherExtensionB);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeAbstractClass.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeAbstractClass.java
@@ -4,9 +4,22 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.OptBoolean;
 
+import java.util.Objects;
+
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "cls", include = JsonTypeInfo.As.PROPERTY, visible = true, requireTypeIdForSubtypes = OptBoolean.TRUE)
 // Because we register them as subtypes on the OpenApiSetupHelper, we don't need to specify JsonSubTypes here.
 // @JsonSubTypes({@JsonSubTypes.Type(SomeExtensionClassA.class), @JsonSubTypes.Type(SomeExtensionClassB.class)})
 public abstract class SomeAbstractClass {
     public String infoOnSuperClass = "someInfoOnAbstractSuperClass";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SomeAbstractClass that)) return false;
+        return Objects.equals(infoOnSuperClass, that.infoOnSuperClass);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(infoOnSuperClass);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeExtensionClassA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeExtensionClassA.java
@@ -1,5 +1,19 @@
 package no.nav.openapi.spec.utils.jackson.dto;
 
+import java.util.Objects;
+
 public class SomeExtensionClassA extends SomeAbstractClass {
     public String extensionA = "extensionA";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SomeExtensionClassA that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(extensionA, that.extensionA);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), extensionA);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeExtensionClassB.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/SomeExtensionClassB.java
@@ -1,5 +1,19 @@
 package no.nav.openapi.spec.utils.jackson.dto;
 
+import java.util.Objects;
+
 public class SomeExtensionClassB extends SomeAbstractClass {
     public String extensionB = "extensionB";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof SomeExtensionClassB that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(extensionB, that.extensionB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), extensionB);
+    }
 }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdExtensionClassA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdExtensionClassA.java
@@ -1,0 +1,24 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+
+@JsonTypeName(value = ThirdExtensionClassA.KODE_A)
+public class ThirdExtensionClassA extends ThirdSuperClass {
+    public static final String KODE_A = "KODE_A";
+    public String propertyA = "AAA";
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ThirdExtensionClassA that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(propertyA, that.propertyA);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), propertyA);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdExtensionClassB.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdExtensionClassB.java
@@ -1,0 +1,23 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+import java.util.Objects;
+
+@JsonTypeName(ThirdExtensionClassB.KODE_B)
+public class ThirdExtensionClassB extends ThirdSuperClass {
+    public static final String KODE_B = "KODE_B";
+    public String propertyB = "BBB";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ThirdExtensionClassB that)) return false;
+        if (!super.equals(o)) return false;
+        return Objects.equals(propertyB, that.propertyB);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), propertyB);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdSuperClass.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ThirdSuperClass.java
@@ -1,0 +1,21 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import java.util.Objects;
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
+public abstract class ThirdSuperClass {
+    public String superInfo = "superInfo";
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ThirdSuperClass that)) return false;
+        return Objects.equals(superInfo, that.superInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(superInfo);
+    }
+}

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
@@ -21,4 +21,6 @@ public class DummyDto {
     public SomeAbstractClass abstractClass = new SomeExtensionClassA();
     // Test of inheritance annotated with JsonSubTypes for all subtypes.
     public OtherAbstractClass otherAbstractClass = new OtherExtensionClassA();
+    // More testing of subtypes, esp discriminator working
+    public ThirdSuperClass thirdSuperClass;
 }


### PR DESCRIPTION
On schemas with generated oneOf refs, we need a discriminator property and in some cases mapping from its value to a schema ref to match what the ObjectMapper expects for serialization/deserialization to/from a subtype.

This therefore adds a DiscriminatorModelConverter that fixes this for generated schemas.