### PR TITLE
Discriminator external property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>no.nav.openapi.spec.utils</groupId>
     <artifactId>openapi-spec-utils</artifactId>
-    <version>2.0.4</version>
+    <version>2.0.5</version>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
@@ -17,7 +17,7 @@ public class SubtypeObjectMappingTest {
     public SubtypeObjectMappingTest() {
         final var modifier = OpenapiCompatObjectMapperModifier.withDefaultModifications();
         this.om = modifier.modify(ObjectMapperFactory.createJson());
-        this.om.registerSubtypes(ThirdExtensionClassA.class, ThirdExtensionClassB.class);
+        this.om.registerSubtypes(ThirdExtensionClassA.class, ThirdExtensionClassB.class, ExternalPropertyIncludeA.class);
     }
 
     @Test
@@ -95,6 +95,23 @@ public class SubtypeObjectMappingTest {
                 final SomeAbstractClass deserialized = reader.readValue(serializedFromTs, SomeAbstractClass.class);
                 assertThat(deserialized).isInstanceOf(SomeExtensionClassA.class);
                 assertThat(deserialized).isEqualTo(a);
+            }
+        }
+    }
+
+    @Test
+    public void testDeSerializationExternalPropertyIncludeContainer() throws IOException {
+        final var reader = this.om.reader();
+        {
+            final var a = new ExternalPropertyIncludeContainer(DummyEnum.DUMMY_V1, new ExternalPropertyIncludeA("tst"));
+            {
+                final var serialized = this.om.writeValueAsString(a);
+                final ExternalPropertyIncludeContainer deserialized = reader.readValue(serialized, ExternalPropertyIncludeContainer.class);
+                assertThat(deserialized).isInstanceOf(ExternalPropertyIncludeContainer.class);
+                assertThat(deserialized).isEqualTo(a);
+            }
+            {
+                // TODO final var serializedFromTs =
             }
         }
     }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/SubtypeObjectMappingTest.java
@@ -111,7 +111,9 @@ public class SubtypeObjectMappingTest {
                 assertThat(deserialized).isEqualTo(a);
             }
             {
-                // TODO final var serializedFromTs =
+                final var serializedFromTs = "{\"included\":{\"tst\":\"tst\"},\"includedDiscriminator\":\"V1\"}";
+                final ExternalPropertyIncludeContainer deserialized = reader.readValue(serializedFromTs, ExternalPropertyIncludeContainer.class);
+                assertThat(deserialized).isEqualTo(a);
             }
         }
     }

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/DummyEnum.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/DummyEnum.java
@@ -6,9 +6,12 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * Copy of enum in openapi package, so that we can get a name collision in test for PrefixStrippingFQNTypeNameResolver.
  */
 public enum DummyEnum {
-    DUMMY_V1("V1"),
-    DUMMY_V2("V2"),
+    DUMMY_V1(DummyEnum.V1),
+    DUMMY_V2(DummyEnum.V2),
     ;
+
+    public static final String V1 = "V1";
+    public static final String V2 = "V2";
 
     @JsonValue
     public final String enumVerdi;

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeA.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeA.java
@@ -1,0 +1,7 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+
+@JsonTypeName(DummyEnum.V1)
+public record ExternalPropertyIncludeA(String tst) implements ExternalPropertyIncludeInterface {
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeContainer.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeContainer.java
@@ -1,0 +1,15 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+public record ExternalPropertyIncludeContainer(
+        // Used as discriminator for the included property
+        DummyEnum includedDiscriminator,
+        @JsonTypeInfo(
+                use = JsonTypeInfo.Id.NAME,
+                include = JsonTypeInfo.As.EXTERNAL_PROPERTY,
+                property = "includedDiscriminator"
+        )
+        ExternalPropertyIncludeInterface included
+) {
+}

--- a/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeInterface.java
+++ b/src/test/java/no/nav/openapi/spec/utils/jackson/dto/ExternalPropertyIncludeInterface.java
@@ -1,0 +1,4 @@
+package no.nav.openapi.spec.utils.jackson.dto;
+
+public sealed interface ExternalPropertyIncludeInterface permits ExternalPropertyIncludeA {
+}

--- a/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
+++ b/src/test/java/no/nav/openapi/spec/utils/openapi/DummyDto.java
@@ -23,4 +23,6 @@ public class DummyDto {
     public OtherAbstractClass otherAbstractClass = new OtherExtensionClassA();
     // More testing of subtypes, esp discriminator working
     public ThirdSuperClass thirdSuperClass;
+    // Test JsonTypeInfo.As.EXTERNAL_PROPERTY discriminator.
+    public ExternalPropertyIncludeContainer includeContainer;
 }


### PR DESCRIPTION
Fixes exception thrown when include = JsonTypeInfo.As.EXTERNAL_PROPERTY was used on a property.

When EXTERNAL_PROPERTY is used, and `@JsonTypeInfo` annotation is set on the property declaration for a type, we don't need to make a discriminator, the "container" type has the discriminator on a separate property, so it will be included in the generated typescript. But it also means the generated typescript will be a simple union type without a clear discriminator.

This change also makes it so that if include = JsonTypeInfo.AS.WRAPPER_OBJECT or WRAPPER_ARRAY, no discriminator will be added by DiscriminatorModelConverter. Not sure what should be done if these options are used, so will ignore them for now.