### PR TITLE
Legg til sif-code-scan i CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,9 @@ jobs:
           cache: 'maven'
       - name: Build and test
         run: mvn verify -e
+
+  sif-code-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+      - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
 
   sif-code-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,5 +24,6 @@ jobs:
   sif-code-scan:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: navikt/sif-gha-workflows/.github/actions/sif-code-scan@main
+


### PR DESCRIPTION
Legger til sif-code-scan som en parallell jobb i CI-workflowen. Denne sjekker koden for sensitive data som fødselsnummer.